### PR TITLE
Add required {algorithms:} parameter to "express-jwt"

### DIFF
--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -1,12 +1,12 @@
 import * as express from "express";
-import jwt from "express-jwt";
+import {expressjwt as jwt} from "express-jwt";
 
 export default function jwtHandler(credentialsRequired: boolean) {
   return [
-    jwt({secret: process.env.APP_KEY!, credentialsRequired}),
+    jwt({secret: process.env.APP_KEY!, credentialsRequired, algorithms: ['HS256']}),
     (req: express.Request, res: express.Response, next: Function) => {
       if (req.user) {
-        req.user.iss = parseInt(String(req.user.iss))
+        req.user.iss = parseInt(String(req.user.iss));
       }
 
       next();


### PR DESCRIPTION
Nie mogę zbudować obrazu ani uruchomić repozytorium lokalnie, przez błąd:

![image](https://github.com/user-attachments/assets/1f75ceab-91d4-44af-9ca8-8cc6173d3f27)


1. Przekazanie `algorithms` jest najwyraźniej konieczne: https://www.npmjs.com/package/express-jwt/v/8.2.0
   
   ![image](https://github.com/user-attachments/assets/e7491c5d-d652-4d58-91c2-d968410cca30)

   @adam-boduch Nie wiem jaki aktualnie algorytm jest używany, najpewniej `HS256`. Nie jestem też na 100% pewien jaki był wybrany jako domyślny.

2. Import `jwt` powinien być przez eksportowany element `expressjwt`: https://www.npmjs.com/package/express-jwt/v/8.2.0#usage
   
![image](https://github.com/user-attachments/assets/15bb5aee-e8b6-46c5-a000-0d71650447df)
